### PR TITLE
add support for C++14 and C++17 standards

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -37,6 +37,7 @@ source=(R-source.tar.gz::"https://cran.r-project.org/src/base-prerelease/R-devel
     shortcut.diff
     trio.diff
     rtools40.diff
+    standards.diff
     create-tcltk-bundle.sh)
 
 # Automatic untar fails due to embedded symlinks
@@ -67,6 +68,7 @@ prepare() {
   patch -Np1 -i "${srcdir}/shortcut.diff"
   patch -Np1 -i "${srcdir}/trio.diff"
   patch -Np1 -i "${srcdir}/rtools40.diff" 
+  patch -Np1 -i "${srcdir}/standards.diff" 
   cp "${srcdir}/cacert.pem" etc/curl-ca-bundle.crt
   mkdir -p Tcl/{bin,bin64,lib,lib64}
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -68,7 +68,7 @@ prepare() {
   patch -Np1 -i "${srcdir}/shortcut.diff"
   patch -Np1 -i "${srcdir}/trio.diff"
   patch -Np1 -i "${srcdir}/rtools40.diff" 
-  patch -Np1 -i "${srcdir}/standards.diff" 
+  patch -Np0 -i "${srcdir}/standards.diff" 
   cp "${srcdir}/cacert.pem" etc/curl-ca-bundle.crt
   mkdir -p Tcl/{bin,bin64,lib,lib64}
 

--- a/standards.diff
+++ b/standards.diff
@@ -1,0 +1,25 @@
+Index: src/gnuwin32/fixed/etc/Makeconf
+===================================================================
+--- src/gnuwin32/fixed/etc/Makeconf	(revision 75583)
++++ src/gnuwin32/fixed/etc/Makeconf	(working copy)
+@@ -81,14 +81,14 @@
+ CXX11FLAGS = -O2 -Wall $(DEBUGFLAG) @EOPTS@
+ CXX11PICFLAGS =
+ CXX11STD = -std=gnu++11
+-CXX14 = 
+-CXX14FLAGS = 
++CXX14 = $(BINPREF)g++ $(M_ARCH)
++CXX14FLAGS = -O2 -Wall $(DEBUGFLAG) @EOPTS@
+ CXX14PICFLAGS =
+-CXX14STD = 
+-CXX17 = 
+-CXX17FLAGS = 
++CXX14STD = -std=gnu++14
++CXX17 = $(BINPREF)g++ $(M_ARCH)
++CXX17FLAGS = -O2 -Wall $(DEBUGFLAG) @EOPTS@
+ CXX17PICFLAGS =
+-CXX17STD = 
++CXX17STD = -std=gnu++17
+ DYLIB_EXT = .dll
+ DYLIB_LD = $(DLL)
+ DYLIB_LDFLAGS = -shared


### PR DESCRIPTION
This PR sets the flags pertaining to the C++14 and C++17 standards with what I would guess they will be set to when R 3.6.0 is released in 2019. Version 8 of `g++` claims to support both standards fully
https://gcc.gnu.org/onlinedocs/gcc-8.2.0/gcc/Standards.html#C_002b_002b-Language
and, in fact, defaults to the C++14 standard (with GNU extensions). Thus, I believe R-testing was already utilizing the C++14 standard to compile packages as long as they did not specify `CXX_STD = CXX11` or `CXX_STD = CXX98` in their `src/Makevars.win` files.